### PR TITLE
Update vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,5 +11,6 @@
     "rsm-binary-io",
     "spdlog",
     "xbyak"
-  ]
+  ],
+  "builtin-baseline": "83972272512ce4ede5fc3b2ba98f6468b179f192"
 }


### PR DESCRIPTION
Added missing JSON field "builtin-baseline" referring to HEAD of vcpkg repository.