### PR TITLE
Fix for SetAlpha not working correctly for first person

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -14,6 +14,7 @@ set(sources ${sources}
 	src/Fixes/CrosshairRefEventVR.cpp
 	src/Fixes/DistantRefLoadCrash.cpp
 	src/Fixes/EffectShaderZBuffer.cpp
+	src/Fixes/FirstPersonAlpha.cpp
 	src/Fixes/FlagSpellsAsNoAbsorb.cpp
 	src/Fixes/IsFurnitureAnimTypeForFurniture.cpp
 	src/Fixes/MapMarkerPlacement.cpp

--- a/src/Fixes.cpp
+++ b/src/Fixes.cpp
@@ -64,6 +64,9 @@ void Fixes::PostLoad::Install()
 	if (fixes.loadEditorIDs) {
 		CacheFormEditorIDs::Install();
 	}
+	if (fixes.firstPersonAlpha) {
+		FirstPersonAlpha::Install();
+	}
 	//UnderWaterCamera::Install(); tbd
 }
 

--- a/src/Fixes.h
+++ b/src/Fixes.h
@@ -62,6 +62,11 @@ namespace Fixes
 		void Install();
 	}
 
+	namespace FirstPersonAlpha
+	{
+		void Install();
+	}
+
 	namespace FlagSpellsAsNoAbsorb
 	{
 		void Install();

--- a/src/Fixes/FirstPersonAlpha.cpp
+++ b/src/Fixes/FirstPersonAlpha.cpp
@@ -16,7 +16,7 @@ namespace Fixes::FirstPersonAlpha
 		}
 
 	private:
-		static RE::BSFadeNode* SetFPAlpha(RE::PlayerCharacter* player, float alpha_value)
+		static RE::NiAVObject* SetFPAlpha(RE::PlayerCharacter* player, float alpha_value)
 		{
 			// fade == false -> alpha_value = 2 to 3
 			// fade == true -> alpha_value = 0 to 1

--- a/src/Fixes/FirstPersonAlpha.cpp
+++ b/src/Fixes/FirstPersonAlpha.cpp
@@ -16,14 +16,14 @@ namespace Fixes::FirstPersonAlpha
 		}
 
 	private:
-		static RE::BSFadeNode* SetFPAlpha(RE::Character* a, float alpha_value)
+		static RE::BSFadeNode* SetFPAlpha(RE::Character* player, float alpha_value)
 		{
 			// fade == false -> alpha_value = 2 to 3
 			// fade == true -> alpha_value = 0 to 1
 			if (alpha_value >= 2) {
 				alpha_value -= 2;
 			}
-			a->Get3D(true)->UpdateMaterialAlpha(alpha_value, false);
+			player->Get3D(true)->UpdateMaterialAlpha(alpha_value, false);
 			return nullptr; // Return null so that the original fade function for 1st person doesn't execute
 		}
 		static inline REL::Relocation<decltype(SetFPAlpha)> _SetFPAlpha;

--- a/src/Fixes/FirstPersonAlpha.cpp
+++ b/src/Fixes/FirstPersonAlpha.cpp
@@ -1,0 +1,37 @@
+#include "Fixes.h"
+
+//Bandaid fix for SetAlpha not working properly for first person
+namespace Fixes::FirstPersonAlpha
+{
+	struct FirstPersonAlpha
+	{
+		static void Install()
+		{
+			REL::Relocation<std::uintptr_t> target { REL_ID(37777, 38722), 0x55 };
+
+			auto& trampoline = SKSE::GetTrampoline();
+			SKSE::AllocTrampoline(14);
+
+			_SetFPAlpha = trampoline.write_call<6>(target.address(), SetFPAlpha);
+		}
+
+	private:
+		static RE::BSFadeNode* SetFPAlpha(RE::Character* a, float alpha_value)
+		{
+			// fade == false -> alpha_value = 2 to 3
+			// fade == true -> alpha_value = 0 to 1
+			if (alpha_value >= 2) {
+				alpha_value -= 2;
+			}
+			a->Get3D(true)->UpdateMaterialAlpha(alpha_value, false);
+			return nullptr; // Return null so that the original fade function for 1st person doesn't execute
+		}
+		static inline REL::Relocation<decltype(SetFPAlpha)> _SetFPAlpha;
+	};
+
+	void Install()
+	{
+		FirstPersonAlpha::Install();
+		logger::info("\t\tInstalled first person alpha fix"sv);
+	}
+}

--- a/src/Fixes/FirstPersonAlpha.cpp
+++ b/src/Fixes/FirstPersonAlpha.cpp
@@ -16,7 +16,7 @@ namespace Fixes::FirstPersonAlpha
 		}
 
 	private:
-		static RE::BSFadeNode* SetFPAlpha(RE::Character* player, float alpha_value)
+		static RE::BSFadeNode* SetFPAlpha(RE::PlayerCharacter* player, float alpha_value)
 		{
 			// fade == false -> alpha_value = 2 to 3
 			// fade == true -> alpha_value = 0 to 1

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -69,6 +69,7 @@ void Settings::Fixes::Load(CSimpleIniA& a_ini)
 	get_value(a_ini, breathingSounds, section, "Breathing Sounds", ";Fix creature breathing sounds persisting after cell change");
 	get_value(a_ini, validateScreenshotFolder, section, "Validate Screenshot Location", ";Validates game screenshot location.\n;Defaults to Skyrim root directory if sScreenshotBaseName ini setting is empty or folder path does not exist");
 	get_value(a_ini, loadEditorIDs, section, "Load EditorIDs", ";Loads editorIDs for skipped forms at runtime");
+	get_value(a_ini, firstPersonAlpha, section, "First Person SetAlpha Fix", ";Fixes SetAlpha function making hands invisible for first person");
 #ifdef SKYRIMVR
 	get_value(a_ini, fixVRCrosshairRefEvent, section, "VR CrosshairRefEvent Fix", "; Trigger CrossHairRefEvent with hand selection (normally requires game controller to enable crosshair events)");
 #endif

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -27,6 +27,7 @@ public:
 		bool          breathingSounds{ true };
 		bool          validateScreenshotFolder{ true };
 		bool          loadEditorIDs{ true };
+		bool          firstPersonAlpha{ true };
 #ifdef SKYRIMVR
 		bool fixVRCrosshairRefEvent{ true };
 #endif


### PR DESCRIPTION
Just a band-aid fix for the issue where SetAlpha function is making hands invisible in first person. Basically just updating the alpha directly for the NiAVObject instead of getting root skeleton for first person and then changing fade amount in BSFadeNode vtable function.

I think the proper solution would be to check the function that is responsible for fading it, might be a bug there. I lack the experience in RE to find it though. The meshes seem to be correct for skeleton, because if you just return the 1st person node manually it's still the same issue. Another thought is perhaps it's related to camera states or something, I got no idea tbh.